### PR TITLE
chore(tooling): stop prettier rewriting generated lockfiles

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,10 @@
+# Generated lockfiles are owned by their package manager, not by prettier.
+# lint-staged runs `prettier --write` over *.yaml, which would otherwise
+# rewrite every quoted key in pnpm-lock.yaml on any commit that touches it,
+# burying real dependency changes under a whole-file reformat.
+pnpm-lock.yaml
+package-lock.json
+
+# Build output and vendored artifacts.
+dist/
+src-tauri/target/

--- a/package.json
+++ b/package.json
@@ -1,86 +1,86 @@
 {
-	"name": "legal-docs-review",
-	"private": true,
-	"version": "0.1.0",
-	"type": "module",
-	"scripts": {
-		"dev": "vite",
-		"dev:lean": "sh ./scripts/dev-lean.sh",
-		"build": "tsc -b && vite build",
-		"preview": "vite preview",
-		"test": "vitest run",
-		"test:watch": "vitest",
-		"tauri": "tauri",
-		"clean": "sh ./scripts/clean-workspace.sh",
-		"clean:heavy": "sh ./scripts/clean-heavy.sh",
-		"clean:full": "sh ./scripts/clean-full.sh",
-		"clean:deep": "sh ./scripts/clean-workspace.sh --with-deps",
-		"clean:dry-run": "sh ./scripts/clean-workspace.sh --dry-run",
-		"prepare": "husky",
-		"commit": "cz",
-		"commitlint": "commitlint",
-		"git:guard:branch": "bash scripts/git/guard-branch.sh",
-		"git:guard:no-main-push": "bash scripts/git/guard-no-main-push.sh",
-		"git:guard:atomic": "bash scripts/git/guard-atomic.sh",
-		"git:guard:generated": "bash scripts/git/guard-generated.sh",
-		"git:guard:large-files": "bash scripts/git/guard-large-files.sh",
-		"git:guard:secrets": "bash scripts/git/guard-secrets.sh",
-		"git:guard:all": "pnpm git:guard:branch && pnpm git:guard:atomic && pnpm git:guard:generated && pnpm git:guard:large-files && pnpm git:guard:secrets",
-		"git:commit:propose": "node scripts/git/propose-commit-message.mjs",
-		"git:session:save": "bash scripts/git/session-save.sh",
-		"git:session:resume": "bash scripts/git/session-resume.sh",
-		"pr:notes": "bash scripts/git/generate-pr-notes.sh",
-		"perf:bundle": "node scripts/perf/bundle-report.mjs",
-		"perf:build": "node scripts/perf/measure-build-time.mjs",
-		"perf:assets": "bash scripts/perf/check-assets.sh",
-		"perf:memory": "node --expose-gc scripts/perf/memory-smoke.mjs",
-		"perf:summary": "node scripts/perf/summarize.mjs",
-		"lint-staged": "lint-staged"
-	},
-	"dependencies": {
-		"@tauri-apps/api": "^2.0.0",
-		"@tauri-apps/plugin-dialog": "^2.6.0",
-		"lucide-react": "^0.460.0",
-		"react": "^19.0.0",
-		"react-dom": "^19.0.0",
-		"react-dropzone": "^14.3.5",
-		"react-hot-toast": "^2.4.1",
-		"react-router": "^7.15.1"
-	},
-	"devDependencies": {
-		"@tauri-apps/cli": "^2.10.0",
-		"@testing-library/jest-dom": "^6.6.0",
-		"@testing-library/react": "^16.1.0",
-		"@types/react": "^19.0.0",
-		"@types/react-dom": "^19.0.0",
-		"@vitejs/plugin-react": "^4.3.0",
-		"autoprefixer": "^10.4.20",
-		"jsdom": "^25.0.0",
-		"postcss": "^8.5.10",
-		"tailwindcss": "^3.4.0",
-		"typescript": "^5.7.0",
-		"vite": "^6.4.3",
-		"vitest": "^3.2.6",
-		"@commitlint/cli": "^19.8.1",
-		"@commitlint/config-conventional": "^19.8.1",
-		"@commitlint/cz-commitlint": "^19.8.1",
-		"@lhci/cli": "^0.15.1",
-		"commitizen": "^4.3.1",
-		"husky": "^9.1.7",
-		"lint-staged": "^15.5.2",
-		"prettier": "^3.6.2"
-	},
-	"config": {
-		"commitizen": {
-			"path": "@commitlint/cz-commitlint"
-		}
-	},
-	"lint-staged": {
-		"*.{js,jsx,ts,tsx,mjs,cjs,json,md,css,scss,yml,yaml}": [
-			"prettier --write"
-		]
-	},
-	"engines": {
-		"node": ">=18"
-	}
+  "name": "legal-docs-review",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "dev:lean": "sh ./scripts/dev-lean.sh",
+    "build": "tsc -b && vite build",
+    "preview": "vite preview",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "tauri": "tauri",
+    "clean": "sh ./scripts/clean-workspace.sh",
+    "clean:heavy": "sh ./scripts/clean-heavy.sh",
+    "clean:full": "sh ./scripts/clean-full.sh",
+    "clean:deep": "sh ./scripts/clean-workspace.sh --with-deps",
+    "clean:dry-run": "sh ./scripts/clean-workspace.sh --dry-run",
+    "prepare": "husky",
+    "commit": "cz",
+    "commitlint": "commitlint",
+    "git:guard:branch": "bash scripts/git/guard-branch.sh",
+    "git:guard:no-main-push": "bash scripts/git/guard-no-main-push.sh",
+    "git:guard:atomic": "bash scripts/git/guard-atomic.sh",
+    "git:guard:generated": "bash scripts/git/guard-generated.sh",
+    "git:guard:large-files": "bash scripts/git/guard-large-files.sh",
+    "git:guard:secrets": "bash scripts/git/guard-secrets.sh",
+    "git:guard:all": "pnpm git:guard:branch && pnpm git:guard:atomic && pnpm git:guard:generated && pnpm git:guard:large-files && pnpm git:guard:secrets",
+    "git:commit:propose": "node scripts/git/propose-commit-message.mjs",
+    "git:session:save": "bash scripts/git/session-save.sh",
+    "git:session:resume": "bash scripts/git/session-resume.sh",
+    "pr:notes": "bash scripts/git/generate-pr-notes.sh",
+    "perf:bundle": "node scripts/perf/bundle-report.mjs",
+    "perf:build": "node scripts/perf/measure-build-time.mjs",
+    "perf:assets": "bash scripts/perf/check-assets.sh",
+    "perf:memory": "node --expose-gc scripts/perf/memory-smoke.mjs",
+    "perf:summary": "node scripts/perf/summarize.mjs",
+    "lint-staged": "lint-staged"
+  },
+  "dependencies": {
+    "@tauri-apps/api": "^2.0.0",
+    "@tauri-apps/plugin-dialog": "^2.6.0",
+    "lucide-react": "^0.460.0",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0",
+    "react-dropzone": "^14.3.5",
+    "react-hot-toast": "^2.4.1",
+    "react-router": "^7.15.1"
+  },
+  "devDependencies": {
+    "@tauri-apps/cli": "^2.10.0",
+    "@testing-library/jest-dom": "^6.6.0",
+    "@testing-library/react": "^16.1.0",
+    "@types/react": "^19.0.0",
+    "@types/react-dom": "^19.0.0",
+    "@vitejs/plugin-react": "^4.3.0",
+    "autoprefixer": "^10.4.20",
+    "jsdom": "^25.0.0",
+    "postcss": "^8.5.10",
+    "tailwindcss": "^3.4.0",
+    "typescript": "^5.7.0",
+    "vite": "^6.4.3",
+    "vitest": "^3.2.6",
+    "@commitlint/cli": "^19.8.1",
+    "@commitlint/config-conventional": "^19.8.1",
+    "@commitlint/cz-commitlint": "^19.8.1",
+    "@lhci/cli": "^0.15.1",
+    "commitizen": "^4.3.1",
+    "husky": "^9.1.7",
+    "lint-staged": "^15.5.2",
+    "prettier": "^3.6.2"
+  },
+  "config": {
+    "commitizen": {
+      "path": "@commitlint/cz-commitlint"
+    }
+  },
+  "lint-staged": {
+    "*.{js,jsx,ts,tsx,mjs,cjs,json,md,css,scss,yml,yaml}": [
+      "prettier --write"
+    ]
+  },
+  "engines": {
+    "node": ">=18"
+  }
 }


### PR DESCRIPTION
## Summary

Adds a `.prettierignore` so prettier stops rewriting generated lockfiles, and normalises `package.json` indentation once so it stops churning too.

## The problem

`lint-staged` is configured as:

```json
"*.{js,jsx,ts,tsx,mjs,cjs,json,md,css,scss,yml,yaml}": ["prettier --write"]
```

That glob includes `*.yaml`, which pulls in `pnpm-lock.yaml`. The committed lockfile is pnpm's own output and has never been prettier-formatted, so the first hook-respecting commit that touches it rewrites the quoting on all 675 package keys.

This surfaced on a react-router security bump. Seven packages actually changed. The commit came out as **6527 lines** across the lockfile, with the real change buried inside. Dependabot has never triggered it because its commits bypass husky, which is why the mismatch has gone unnoticed.

`package.json` has the same issue in miniature: it is tab-indented while every source file in the repo is space-indented, so prettier retabs all 168 lines on any commit that touches it.

## The change

- **`.prettierignore`** covering `pnpm-lock.yaml`, `package-lock.json`, and build output. Generated lockfiles are owned by their package manager, not by a formatter.
- **`package.json` normalised** from tabs to spaces, once, here. This is prettier's default and already matches the rest of the codebase. Folding it in now keeps future dependency PRs to a readable diff. The change is whitespace only; parsed JSON is byte-for-byte equivalent.

No `.prettierrc` is added. Prettier's defaults already match the repository's real style, so configuring one would be redundant.

## Verification

The case that actually matters is a commit whose only staged file is the lockfile, since that is exactly what a dependency bump looks like. If prettier errored when all its inputs were ignored, this change would break those commits instead of fixing them.

| Check | Result |
|---|---|
| `prettier --write pnpm-lock.yaml` (only input, ignored) | exit 0, file untouched |
| `prettier --write pnpm-lock.yaml package.json` | exit 0, lockfile skipped |
| `pnpm install --frozen-lockfile` | clean |
| `pnpm test` | 14 tests across 4 files, passing |
| `package.json` semantic equality | identical after parse |

## Follow-up

The react-router security bump lands separately once this is in, so its diff shows the dependency change rather than a whole-file reformat.
