### PR TITLE
chore(privacy): stop publishing absolute home paths

### DIFF
--- a/.codex/actions/_artifact_env.sh
+++ b/.codex/actions/_artifact_env.sh
@@ -12,7 +12,7 @@ else
 fi
 
 RUN_ID="${CODEX_RUN_ID:-$(date +%Y%m%dT%H%M%S)-$$}"
-CODEX_CACHE_ROOT="${CODEX_CACHE_ROOT:-/Users/d/Library/Caches/Codex}"
+CODEX_CACHE_ROOT="${CODEX_CACHE_ROOT:-$HOME/Library/Caches/Codex}"
 CODEX_BUILD_ROOT="${CODEX_BUILD_ROOT:-$CODEX_CACHE_ROOT/build}"
 CODEX_LOG_ROOT="${CODEX_LOG_ROOT:-$CODEX_CACHE_ROOT/logs}"
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,12 +2,12 @@
 
 ## Communication Contract
 
-- Inherit global Codex communication and reporting rules from `/Users/d/.codex/AGENTS.override.md` and `/Users/d/.codex/policies/communication/BigPictureReportingV1.md`.
+- Inherit global Codex communication and reporting rules from `~/.codex/AGENTS.override.md` and `~/.codex/policies/communication/BigPictureReportingV1.md`.
 - Repo-specific instructions below add project constraints only; do not restate global voice or status-reporting rules here.
 <!-- comm-contract:end -->
 
 ## Inherited Operating Rules
 
-- Inherit global git, review/fix, testing, docs, skill-use, and reporting gates from `/Users/d/.codex/AGENTS.md` and active session instructions.
+- Inherit global git, review/fix, testing, docs, skill-use, and reporting gates from `~/.codex/AGENTS.md` and active session instructions.
 - Use `.codex/verify.commands` and `.codex/scripts/run_verify_commands.sh` as this repo-local verification authority when present.
 - Add repo-specific constraints here only when this project has instructions that differ from global Codex defaults.


### PR DESCRIPTION
Replaces absolute home paths with `~` in tracked files, so the repository stops
publishing the operator's macOS account name and local directory layout.

This is one of 31 identical branches across the portfolio. Every one of them was
committed and pushed but none was ever opened as a pull request, so the paths
stayed on the default branch and stayed public. Merging this is what actually
removes them.

No credential, token, key material or personal name was exposed. What leaks is
the account name and the shape of the directories under it, which is a
fingerprinting signal rather than a breach.

Some occurrences are deliberately left in place, and should not be redacted in a
follow-up:

- tests that assert a named file does **not** contain the path. The literal
  there is the needle the test searches for, not a leak.
- sandbox-escape tests that attempt to read or write a real absolute host path.
  Redacting the path removes the thing the test proves.
- sealed evidence artifacts pinned by a SHA-256 contract test. A text edit
  invalidates the proof rather than redacting it; those need a re-run that
  produces a fresh receipt, not a substitution.

Test fixtures that must stay a *detectable* private path use `/Users/example/...`
rather than `~`, because the validator they exercise keys on `/users|home|root/`
and not on the account name. That keeps each assertion meaningful while naming
nobody.
